### PR TITLE
db: Store output in a separate table

### DIFF
--- a/blade/bep/BUILD.bazel
+++ b/blade/bep/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 
 rust_library(
     name = "bep",
@@ -46,4 +46,10 @@ rust_library(
         "@crate//:walkdir",
         "@rules_rust//tools/runfiles",
     ],
+)
+
+rust_test(
+    name = "bep_test",
+    size = "small",
+    crate = ":bep",
 )

--- a/blade/bep/print_event.rs
+++ b/blade/bep/print_event.rs
@@ -20,7 +20,7 @@ impl crate::EventHandler for Handler {
             return Ok(());
         }
         let desc = event.descriptor();
-        let dm = event.transcode_to_dynamic();
+        let mut dm: prost_reflect::DynamicMessage = event.transcode_to_dynamic();
         let oneof = match desc.oneofs().next() {
             None => {
                 return Ok(());
@@ -30,6 +30,7 @@ impl crate::EventHandler for Handler {
         let _ = oneof.fields().try_for_each(|f| {
             if dm.has_field(&f) && re.is_match(f.field_descriptor_proto().type_name()) {
                 let type_name = f.field_descriptor_proto().name();
+                dm.clear_field_by_name("children");
                 let j = serde_json::ser::to_string(&dm).map_err(|_| ())?;
                 tracing::info!(type_name, "{}", j);
                 return Err(());

--- a/blade/bep/progress.rs
+++ b/blade/bep/progress.rs
@@ -1,27 +1,37 @@
 use anyhow::Context;
 use build_event_stream_proto::build_event_stream;
 use state::DBManager;
+
+const DELETE_LINE_SEQ: &str = "\x1b[1A\x1b[K";
+
 pub(crate) struct Handler {}
 
-fn cleanup(orig: &str, stdout: &str, stderr: &str) -> String {
-    let orig_lines = orig.split('\n').collect::<Vec<_>>();
-    let orig_num_lines = if !orig.is_empty() {
-        orig_lines.len()
-    } else {
-        0
-    };
+fn cleanup(stdout: &str, stderr: &str) -> (u32, Vec<String>) {
     let clean_stdout = stdout.replace('\r', "");
     let clean_stderr = stderr.replace('\r', "");
     let err_lines = clean_stderr.split('\n');
-    let mut lines = orig_lines.into_iter().chain(err_lines).collect::<Vec<_>>();
+    let mut lines = clean_stdout
+        .split('\n')
+        .chain(err_lines)
+        .map(String::from)
+        .collect::<Vec<_>>();
     let mut to_remove = vec![];
-    for (i, l) in lines.iter().enumerate().skip(orig_num_lines) {
-        let c = l.matches("\x1b[1A\x1b[K").count();
+    let mut database_remove = 0;
+    for (i, l) in lines.iter_mut().enumerate() {
+        // This logic assumes that this delete lines sequence is always on a line of its own.
+        // This happens to be the case in Bazel.
+        let c = l.matches(DELETE_LINE_SEQ).count();
         for j in 0..c {
+            if i - 1 < j {
+                database_remove = std::cmp::max(j + 1 - i, database_remove);
+                continue;
+            }
             to_remove.push(i - 1 - j);
         }
+        if c > 0 {
+            *l = l.replace(DELETE_LINE_SEQ, "");
+        }
     }
-
     for i in to_remove {
         if i >= lines.len() {
             tracing::warn!(
@@ -31,15 +41,14 @@ fn cleanup(orig: &str, stdout: &str, stderr: &str) -> String {
             );
             continue;
         }
-        lines[i] = "";
+        lines[i] = "".to_string();
     }
-    lines.insert(orig_num_lines, &clean_stdout);
-    lines
+    let out = lines
         .into_iter()
         .filter(|s| !s.is_empty())
-        .collect::<Vec<_>>()
-        .join("\n")
-        .to_string()
+        .collect::<Vec<String>>();
+
+    (database_remove.try_into().unwrap(), out)
 }
 
 impl crate::EventHandler for Handler {
@@ -55,17 +64,47 @@ impl crate::EventHandler for Handler {
                 return Ok(());
             }
             let mut db = db_mgr.get().context("failed to get db handle")?;
-            let output = db.get_progress(invocation_id)?;
-            let progress = cleanup(&output, &p.stdout, &p.stderr);
-            db.update_shallow_invocation(
-                invocation_id,
-                Box::new(move |i: &mut state::InvocationResults| {
-                    i.output = progress;
-                    Ok(())
-                }),
-            )
-            .context("failed to update progress")?;
+            let progress = cleanup(&p.stdout, &p.stderr);
+            if progress.0 > 0 {
+                // Try our best. If it doesn't work out, just log and continue.
+                _ = db
+                    .delete_last_output_lines(invocation_id, progress.0)
+                    .inspect_err(|e| {
+                        tracing::warn!(
+                            "error deleting {} lines for invocation {}: {:#?}",
+                            progress.0,
+                            invocation_id,
+                            e
+                        );
+                    });
+            }
+            db.insert_output_lines(invocation_id, progress.1)
+                .context("failed to update progress")?;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::progress::{cleanup, DELETE_LINE_SEQ};
+
+    fn make<S, T>(del: T, lines: &[S]) -> (u32, Vec<String>)
+    where
+        T: Into<u32>,
+        S: ToString,
+    {
+        (del.into(), lines.iter().map(|s| s.to_string()).collect())
+    }
+
+    #[test]
+    fn test_cleanup() {
+        assert_eq!(cleanup("a", "b"), make(0_u32, &["a", "b"]));
+        assert_eq!(cleanup("", "b"), make(0_u32, &["b"]));
+        assert_eq!(cleanup("a", ""), make(0_u32, &["a"]));
+        assert_eq!(cleanup("", ""), (0_u32, Vec::new()));
+        assert_eq!(cleanup(&("a\r\nb\r\n".to_owned() + DELETE_LINE_SEQ + DELETE_LINE_SEQ), "ab"), make(0_u32, &["ab"]));
+        assert_eq!(cleanup(&("a\r\nb\r\n".to_owned() + DELETE_LINE_SEQ + DELETE_LINE_SEQ), "ab"), make(0_u32, &["ab"]));
+        assert_eq!(cleanup(&("a\r\nb\r\n".to_owned() + DELETE_LINE_SEQ + DELETE_LINE_SEQ + DELETE_LINE_SEQ), "ab"), make(1_u32, &["ab"]));
     }
 }

--- a/blade/bep/target.rs
+++ b/blade/bep/target.rs
@@ -119,13 +119,15 @@ impl crate::EventHandler for Handler {
                     invocation_id,
                     &label,
                     match build_event_stream::aborted::AbortReason::try_from(a.reason) {
-                        Ok(build_event_stream::aborted::AbortReason::Skipped|build_event_stream::aborted::AbortReason::UserInterrupted) => {
-                            state::Status::Skip
-                        },
+                        Ok(
+                            build_event_stream::aborted::AbortReason::Skipped
+                            | build_event_stream::aborted::AbortReason::UserInterrupted,
+                        ) => state::Status::Skip,
                         _ => state::Status::Fail,
                     },
                     std::time::SystemTime::now(),
-                ).or_else(|_| {
+                )
+                .or_else(|_| {
                     // If the target was not found, we can still log the abort
                     db.upsert_target(
                         invocation_id,

--- a/blade/db/postgres/migrations/2025-06-20-211740_newoutput/down.sql
+++ b/blade/db/postgres/migrations/2025-06-20-211740_newoutput/down.sql
@@ -1,0 +1,31 @@
+-- This file should undo anything in `up.sql`
+-- Migration to Undo Previous Changes
+
+-- Step 1: Add the 'output' column back to Invocations
+ALTER TABLE Invocations
+ADD COLUMN output TEXT NOT NULL DEFAULT ''; -- Add NOT NULL and a default empty string for new rows
+
+-- Important Note for Step 1:
+-- If your 'output' column previously allowed NULLs, adjust the above line:
+-- ALTER TABLE Invocations
+-- ADD COLUMN output TEXT;
+-- You might also want to set a default value for existing rows that will get NULL initially.
+-- For simplicity and assuming previous 'output' was NOT NULL, we use NOT NULL DEFAULT ''.
+
+-- Step 2: Migrate data back from InvocationOutput to Invocations
+-- This aggregates the lines back into a single text block, preserving order.
+UPDATE Invocations inv
+SET output = (
+    SELECT STRING_AGG(io.line, E'\n' ORDER BY io.id)
+    FROM InvocationOutput io
+    WHERE io.invocation_id = inv.id
+)
+WHERE EXISTS (SELECT 1 FROM InvocationOutput io WHERE io.invocation_id = inv.id);
+
+-- Handle cases where an invocation might have had no output (if original 'output' could be empty/null)
+-- If an invocation had no entries in InvocationOutput, its 'output' column would remain ''.
+-- If you need to revert to NULL for such cases, you might do:
+-- UPDATE Invocations SET output = NULL WHERE output = ''; -- Only if 'output' was nullable
+
+-- Step 3: Drop the InvocationOutput table
+DROP TABLE IF EXISTS InvocationOutput;

--- a/blade/db/postgres/migrations/2025-06-20-211740_newoutput/up.sql
+++ b/blade/db/postgres/migrations/2025-06-20-211740_newoutput/up.sql
@@ -1,0 +1,17 @@
+-- Your SQL goes here
+
+CREATE TABLE InvocationOutput (
+    id SERIAL PRIMARY KEY,
+    invocation_id TEXT NOT NULL REFERENCES Invocations(id) ON DELETE CASCADE,
+    line TEXT NOT NULL
+);
+
+INSERT INTO InvocationOutput (invocation_id, line)
+SELECT
+    i.id,
+    UNNEST(STRING_TO_ARRAY(i.output, E'\n')) AS line
+FROM
+    Invocations i;
+
+ALTER TABLE Invocations
+DROP COLUMN output;

--- a/blade/db/postgres/mod.rs
+++ b/blade/db/postgres/mod.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap};
+use std::collections::HashMap;
 
 use anyhow::{Context, anyhow};
 use diesel::{prelude::*, r2d2::ConnectionManager};
@@ -231,9 +231,7 @@ impl state::DB for Postgres {
             .order(schema::invocationoutput::id.asc())
             .load::<String>(&mut self.conn)
         {
-            Ok(res) => {
-                Ok(res.join("\n"))
-            },
+            Ok(res) => Ok(res.join("\n")),
             Err(e) => match e {
                 diesel::result::Error::NotFound => Ok("".to_string()),
                 _ => Err(e).context("failed to get progress"),
@@ -244,7 +242,7 @@ impl state::DB for Postgres {
     fn delete_last_output_lines(&mut self, id: &str, num_lines: u32) -> anyhow::Result<()> {
         let to_delete = schema::invocationoutput::table
             .filter(schema::invocationoutput::invocation_id.eq(id))
-            .order(schema::invocationoutput::id.asc())
+            .order(schema::invocationoutput::id.desc())
             .limit(num_lines.into())
             .select(schema::invocationoutput::id)
             .load::<i32>(&mut self.conn);
@@ -815,5 +813,37 @@ mod tests {
         assert_eq!(res.cmd_line, opts.cmd_line);
         assert_eq!(res.explicit_cmd_line, opts.explicit_cmd_line);
         assert_eq!(res.build_metadata, opts.build_metadata);
+    }
+
+    fn make<S>(lines: &[S]) -> Vec<String>
+    where
+        S: ToString,
+    {
+        lines.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn test_progress() {
+        let tmp = tempdir::TempDir::new("test_test").unwrap();
+        let harness = harness::new(tmp.path().to_str().unwrap()).unwrap();
+        let uri = harness.uri();
+        super::init_db(&uri).unwrap();
+        let mgr = crate::manager::PostgresManager::new(&uri).unwrap();
+        let mut db = mgr.get().unwrap();
+        let inv = state::InvocationResults {
+            id: "blah".to_string(),
+            command: "test".to_string(),
+            status: state::Status::Fail,
+            start: std::time::SystemTime::now(),
+            ..Default::default()
+        };
+        db.upsert_shallow_invocation(&inv).unwrap();
+        let initial = vec!["a", "b", "c", "d"];
+        db.insert_output_lines(&inv.id, make(&initial)).unwrap();
+        let prog = db.get_progress(&inv.id).unwrap();
+        assert_eq!(prog, "a\nb\nc\nd");
+        db.delete_last_output_lines(&inv.id, 2_u32).unwrap();
+        let prog = db.get_progress(&inv.id).unwrap();
+        assert_eq!(prog, "a\nb");
     }
 }

--- a/blade/db/postgres/models.rs
+++ b/blade/db/postgres/models.rs
@@ -270,15 +270,7 @@ impl TestArtifact {
 }
 
 #[derive(
-    Serialize,
-    Deserialize,
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    Insertable,
-    AsChangeset,
-    Associations,
+    Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Insertable, AsChangeset, Associations,
 )]
 #[diesel(table_name = super::schema::invocationoutput)]
 #[diesel(belongs_to(Invocation, foreign_key = invocation_id))]

--- a/blade/db/postgres/models.rs
+++ b/blade/db/postgres/models.rs
@@ -21,7 +21,6 @@ pub struct Invocation {
     pub status: String,
     pub start: time::OffsetDateTime,
     pub end: Option<time::OffsetDateTime>,
-    pub output: String,
     pub command: String,
     pub pattern: Option<String>,
 }
@@ -33,7 +32,6 @@ impl Invocation {
             status: ir.status.to_string(),
             start: ir.start.into(),
             end: ir.end.map(core::convert::Into::into),
-            output: ir.output.clone(),
             command: ir.command.clone(),
             pattern: Some(ir.pattern.join(",")),
         })
@@ -43,7 +41,6 @@ impl Invocation {
         state::InvocationResults {
             id: self.id,
             status: state::Status::parse(&self.status),
-            output: self.output,
             start: crate::time::to_systemtime(&self.start)
                 .unwrap_or_else(|_| std::time::SystemTime::now()),
             end: self.end.map(|e| {
@@ -270,4 +267,22 @@ impl TestArtifact {
             uri: t.uri.clone(),
         }
     }
+}
+
+#[derive(
+    Serialize,
+    Deserialize,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Insertable,
+    AsChangeset,
+    Associations,
+)]
+#[diesel(table_name = super::schema::invocationoutput)]
+#[diesel(belongs_to(Invocation, foreign_key = invocation_id))]
+pub struct InvocationOutput {
+    pub invocation_id: String,
+    pub line: String,
 }

--- a/blade/db/postgres/schema.rs
+++ b/blade/db/postgres/schema.rs
@@ -6,7 +6,6 @@ diesel::table! {
         status -> Text,
         start -> Timestamptz,
         end -> Nullable<Timestamptz>,
-        output -> Text,
         command -> Text,
         pattern -> Nullable<Text>,
     }
@@ -69,6 +68,14 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    invocationoutput (id) {
+        id -> Int4,
+        invocation_id -> Text,
+        line -> Text,
+    }
+}
+
 diesel::joinable!(options -> invocations (invocation_id));
 diesel::joinable!(targets -> invocations (invocation_id));
 diesel::joinable!(testartifacts -> invocations (invocation_id));
@@ -76,6 +83,7 @@ diesel::joinable!(testartifacts -> testruns (test_run_id));
 diesel::joinable!(testruns -> invocations (invocation_id));
 diesel::joinable!(testruns -> tests (test_id));
 diesel::joinable!(tests -> invocations (invocation_id));
+diesel::joinable!(invocationoutput -> invocations (invocation_id));
 
 diesel::allow_tables_to_appear_in_same_query!(
     invocations,

--- a/blade/db/sqlite/migrations/2025-06-21-082528_newoutput/down.sql
+++ b/blade/db/sqlite/migrations/2025-06-21-082528_newoutput/down.sql
@@ -1,0 +1,27 @@
+-- This file should undo anything in `up.sql`
+-- Step 1: Add the 'output' column back to Invocations
+-- Note: SQLite does not support ADD COLUMN NOT NULL without a default value
+-- for existing rows. If you want it NOT NULL, you usually need to recreate the table.
+-- Assuming original 'output' was NOT NULL based on your schema.
+-- This will add a nullable 'output' column initially.
+ALTER TABLE Invocations ADD COLUMN output TEXT;
+
+-- Step 2: Migrate data back from InvocationOutput to Invocations
+-- This aggregates lines back into a single TEXT block, ordered by ID.
+-- SQLite's GROUP_CONCAT is used for aggregation.
+UPDATE Invocations
+SET output = (
+    SELECT GROUP_CONCAT(line, X'0A') -- X'0A' is the hex representation for newline character
+    FROM InvocationOutput
+    WHERE InvocationOutput.invocation_id = Invocations.id
+    ORDER BY InvocationOutput.id -- Ensure order is preserved
+);
+
+-- Handle cases where an invocation might not have any output entries in InvocationOutput.
+-- If you want NULL for these, do:
+-- UPDATE Invocations SET output = NULL WHERE output IS NULL; -- (if you added it nullable)
+-- Or if you want empty string (which is how ADD COLUMN TEXT without default would appear for existing data)
+-- UPDATE Invocations SET output = '' WHERE output IS NULL;
+
+-- Step 3: Drop the InvocationOutput table
+DROP TABLE IF EXISTS InvocationOutput;

--- a/blade/db/sqlite/migrations/2025-06-21-082528_newoutput/up.sql
+++ b/blade/db/sqlite/migrations/2025-06-21-082528_newoutput/up.sql
@@ -1,0 +1,32 @@
+-- Your SQL goes here
+-- Create the new InvocationOutput table
+CREATE TABLE InvocationOutput (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    invocation_id TEXT NOT NULL,
+    line TEXT NOT NULL,
+    -- Add a foreign key constraint.
+    -- SQLite's foreign key constraints are only enforced if PRAGMA foreign_keys = ON;
+    FOREIGN KEY (invocation_id) REFERENCES Invocations(id) ON DELETE CASCADE
+);
+
+-- Copy data from the old 'output' column into the new 'InvocationOutput' table.
+-- SQLite doesn't have UNNEST or STRING_TO_ARRAY directly.
+-- This part is the trickiest in pure SQL for SQLite.
+-- For actual data splitting, you would typically do this in application code (Rust).
+-- For this SQL migration, we'll assume a simpler approach or that `output`
+-- was single-line if this pure SQL migration were to be runnable.
+--
+-- HOWEVER, since you are using a multi-line `output` column, doing this
+-- in pure SQLite SQL with `STRING_TO_ARRAY` is NOT feasible.
+--
+-- The most practical way to handle multi-line splitting during a SQLite migration
+-- is to use application code (e.g., Rust with Diesel).
+--
+-- But if we HAD to do it in SQL and assume output is just one line per `Invocation`
+-- or we put the *entire* output into one `InvocationOutput` line, it would be:
+INSERT INTO InvocationOutput (invocation_id, line)
+SELECT id, output FROM Invocations;
+
+-- Drop the 'output' column from Invocations
+-- SQLite's ALTER TABLE DROP COLUMN is supported in newer versions (3.35.0+)
+ALTER TABLE Invocations DROP COLUMN output;

--- a/blade/db/sqlite/models.rs
+++ b/blade/db/sqlite/models.rs
@@ -22,7 +22,6 @@ pub struct Invocation {
     pub status: String,
     pub start: time::OffsetDateTime,
     pub end: Option<time::OffsetDateTime>,
-    pub output: String,
     pub command: String,
     pub pattern: Option<String>,
 }
@@ -34,7 +33,6 @@ impl Invocation {
             status: ir.status.to_string(),
             start: ir.start.into(),
             end: ir.end.map(core::convert::Into::into),
-            output: ir.output.clone(),
             command: ir.command.clone(),
             pattern: Some(ir.pattern.join(",")),
         })
@@ -44,7 +42,6 @@ impl Invocation {
         state::InvocationResults {
             id: self.id,
             status: state::Status::parse(&self.status),
-            output: self.output,
             start: crate::time::to_systemtime(&self.start)
                 .unwrap_or_else(|_| std::time::SystemTime::now()),
             end: self.end.map(|e| {
@@ -275,4 +272,25 @@ impl TestArtifact {
             uri: t.uri.clone(),
         }
     }
+}
+
+#[derive(
+    Serialize,
+    Deserialize,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Queryable,
+    QueryableByName,
+    Selectable,
+    Insertable,
+    AsChangeset,
+    Associations,
+)]
+#[diesel(table_name = super::schema::InvocationOutput)]
+#[diesel(belongs_to(Invocation, foreign_key = invocation_id))]
+pub struct InvocationOutput {
+    pub invocation_id: String,
+    pub line: String,
 }

--- a/blade/db/sqlite/schema.rs
+++ b/blade/db/sqlite/schema.rs
@@ -6,7 +6,6 @@ diesel::table! {
         status -> Text,
         start -> TimestamptzSqlite,
         end -> Nullable<TimestamptzSqlite>,
-        output -> Text,
         command -> Text,
         pattern -> Nullable<Text>,
     }
@@ -69,6 +68,14 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    InvocationOutput (id) {
+        id -> Integer,
+        invocation_id -> Text,
+        line -> Text,
+    }
+}
+
 diesel::joinable!(Options -> Invocations (invocation_id));
 diesel::joinable!(Targets -> Invocations (invocation_id));
 diesel::joinable!(TestArtifacts -> Invocations (invocation_id));
@@ -76,6 +83,7 @@ diesel::joinable!(TestArtifacts -> TestRuns (test_run_id));
 diesel::joinable!(TestRuns -> Invocations (invocation_id));
 diesel::joinable!(TestRuns -> Tests (test_id));
 diesel::joinable!(Tests -> Invocations (invocation_id));
+diesel::joinable!(InvocationOutput -> Invocations (invocation_id));
 
 diesel::allow_tables_to_appear_in_same_query!(
     Invocations,

--- a/blade/routes/summary.rs
+++ b/blade/routes/summary.rs
@@ -26,7 +26,7 @@ pub async fn get_output(uuid: String) -> Result<String, ServerFnError> {
 #[component]
 pub fn Summary() -> impl IntoView {
     let invocation = expect_context::<RwSignal<state::InvocationResults>>();
-    let (output, set_output) = signal("".to_string());
+    let (output, set_output) = signal("Loading...".to_string());
     let output_res = LocalResource::new(move||{
         let id = invocation.read_only().read().id.clone();
         async move {

--- a/blade/state/lib.rs
+++ b/blade/state/lib.rs
@@ -70,7 +70,6 @@ pub struct InvocationResults {
     pub targets: HashMap<String, Target>,
     pub tests: HashMap<String, Test>,
     pub status: Status,
-    pub output: String,
     pub start: std::time::SystemTime,
     pub end: Option<std::time::SystemTime>,
     pub command: String,
@@ -84,7 +83,6 @@ impl Default for InvocationResults {
             targets: HashMap::new(),
             tests: HashMap::new(),
             status: Status::Unknown,
-            output: "".into(),
             command: "".into(),
             pattern: vec![],
             start: std::time::UNIX_EPOCH,
@@ -125,6 +123,8 @@ pub trait DB {
     fn delete_invocations_since(&mut self, ts: &std::time::SystemTime) -> anyhow::Result<usize>;
     fn insert_options(&mut self, id: &str, options: &BuildOptions) -> anyhow::Result<()>;
     fn get_options(&mut self, id: &str) -> anyhow::Result<BuildOptions>;
+    fn delete_last_output_lines(&mut self, id: &str, num_lines: u32) -> anyhow::Result<()>;
+    fn insert_output_lines(&mut self, id: &str, lines: Vec<String>) -> anyhow::Result<()>;
 }
 
 pub trait DBManager: std::marker::Send + std::marker::Sync {


### PR DESCRIPTION
This makes the invocation smaller since we don't have to fetch the output every time, allowing it to update faster.

We can also fetch the output separately.